### PR TITLE
Implement authentication checking methods

### DIFF
--- a/src/authenticate.ts
+++ b/src/authenticate.ts
@@ -1,0 +1,125 @@
+import * as jose from 'jose';
+import { validate as uuidValidate } from 'uuid';
+import { URL } from 'node:url';
+import { ALG, VER_NUM, VER_PREFIX } from './sign.ts';
+import { MalformedTokenError, UnauthorizedError } from './errors.ts';
+import { appendPathToUrl } from './util.ts';
+
+export type GetJWKS = (data: { kid: string; iss: URL }) => jose.JWTVerifyGetKey;
+
+export type AuthenticateOptions = {
+  baseIssuer: URL;
+  getJWKS: GetJWKS;
+  verifyOptions?: jose.JWTVerifyOptions;
+};
+
+function validateIssuer(
+  iss: unknown,
+  baseIssuer: URL
+): { issuerKid: string; iss: string } {
+  if (typeof iss !== 'string' || !iss) {
+    throw new MalformedTokenError('Missing issuer in token');
+  }
+  let prefix = baseIssuer.toString();
+  if (!prefix.endsWith('/')) {
+    prefix += '/';
+  }
+  if (!iss.startsWith(prefix)) {
+    throw new MalformedTokenError('Invalid issuer');
+  }
+  const issuerKid = iss.slice(prefix.length);
+  if (!uuidValidate(issuerKid)) {
+    throw new MalformedTokenError('Invalid issuer');
+  }
+  return { issuerKid, iss };
+}
+
+function validateKid(
+  issuerKid: string,
+  protectedHeader: jose.JoseHeaderParameters
+): string {
+  if (protectedHeader.kid !== issuerKid) {
+    throw new MalformedTokenError('Mismatched kid compared to issuer');
+  }
+  return issuerKid;
+}
+
+function validateVersion(unverified: jose.JWTPayload): number {
+  const { ver } = unverified;
+  if (typeof ver !== 'string') {
+    throw new MalformedTokenError('Invalid version');
+  }
+  // In the future, consider adding Regep.Escape(VER_PREFIX) once it's accepted into node
+  // It's not needed now because VER_PREFIX doesn't contain any regex special characters
+  const match = ver.match(new RegExp(`^${VER_PREFIX}(\\d{1,3})$`));
+  if (match === null || match.length === 0 || match[1] === undefined) {
+    throw new MalformedTokenError('Invalid version');
+  }
+  const parsed = parseInt(match[1], 10); // The regex prevents this from throwing
+  if (parsed > VER_NUM) {
+    throw new MalformedTokenError('Invalid version');
+  }
+  return parsed;
+}
+
+export async function shouldAuthenticate(
+  token: string,
+  baseIssuer: URL
+): Promise<boolean> {
+  let unverified: jose.JWTPayload;
+  let protectedHeader: jose.JoseHeaderParameters;
+  try {
+    unverified = jose.decodeJwt(token);
+    protectedHeader = jose.decodeProtectedHeader(token);
+    const { issuerKid } = validateIssuer(unverified.iss, baseIssuer);
+    validateKid(issuerKid, protectedHeader);
+    validateVersion(unverified);
+    return true;
+  } catch (err) {
+    return false;
+  }
+}
+
+export function createGetJWKS(
+  baseIssuer: URL,
+  options?: jose.RemoteJWKSetOptions
+): GetJWKS {
+  return (data: { iss: URL }) => {
+    // Strictly speaking the authenticate() function will also validate the issuer
+    // but adding defense-in-depth is a good idea as this is a key part of ensuring
+    // security of the feature
+    validateIssuer(data.iss.toString(), baseIssuer);
+    const url = appendPathToUrl(data.iss, '.well_known/jwks.json');
+    return jose.createRemoteJWKSet(url, options);
+  };
+}
+
+export async function authenticate(
+  token: string,
+  options: AuthenticateOptions
+): Promise<jose.JWTPayload> {
+  let unverified: jose.JWTPayload;
+  let protectedHeader: jose.JoseHeaderParameters;
+  try {
+    unverified = jose.decodeJwt(token);
+    protectedHeader = jose.decodeProtectedHeader(token);
+  } catch (err) {
+    throw new MalformedTokenError('Invalid token', { cause: err });
+  }
+  validateVersion(unverified);
+  const { issuerKid, iss } = validateIssuer(unverified.iss, options.baseIssuer);
+  const kid = validateKid(issuerKid, protectedHeader);
+  try {
+    const { payload } = await jose.jwtVerify(
+      token,
+      options.getJWKS({ kid, iss: new URL(iss) }),
+      {
+        ...options.verifyOptions,
+        algorithms: [ALG],
+      }
+    );
+    return payload;
+  } catch (err) {
+    throw new UnauthorizedError('Failed to verify token', { cause: err });
+  }
+}

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -4,8 +4,9 @@ type StatusCode = keyof typeof STATUS_CODES;
 export enum errorType {
   UNKNOWN = 'unknown',
   INCORRECT_USAGE = 'incorrect_usage',
-  INVALID_INPUT = 'invalid_input',
   SIGNING_ERROR = 'signing_error',
+  MALFORMED_TOKEN = 'malformed_token',
+  UNAUTHORIZED = 'unauthorized',
 }
 
 export class JapikeyError extends Error {
@@ -16,6 +17,33 @@ export class JapikeyError extends Error {
     options?: ErrorOptions
   ) {
     super(message, options);
+  }
+}
+
+/**
+ * When authenticating a token, any initial validation error for parsing
+ * becomes a 401- MalformedTokenError.
+ * This includes things like: missing token, not a JWT, missing kid etc
+ * Once the token is verified, other errors become 403-level errors
+ */
+export class MalformedTokenError extends JapikeyError {
+  constructor(message: string, options?: ErrorOptions) {
+    super(
+      401,
+      errorType.MALFORMED_TOKEN,
+      'The token is missing or not in the correct format',
+      options
+    );
+  }
+}
+
+/**
+ * When authenticating a token, if the token can be parsed, but access is not granted,
+ * a 403 Unauthorized error is thrown
+ */
+export class UnauthorizedError extends JapikeyError {
+  constructor(message: string, options?: ErrorOptions) {
+    super(403, errorType.UNAUTHORIZED, message, options);
   }
 }
 
@@ -39,12 +67,6 @@ export class UnexpectedError extends JapikeyError {
 export class UnknownError extends JapikeyError {
   constructor(message: string, options?: ErrorOptions) {
     super(500, errorType.UNKNOWN, message, options);
-  }
-}
-
-export class InvalidInputError extends JapikeyError {
-  constructor(message: string, options?: ErrorOptions) {
-    super(400, errorType.INVALID_INPUT, message, options);
   }
 }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,18 @@
+import { URL } from 'node:url';
+
+export function appendPathToUrl(base: URL, path: string): URL {
+  if (!path) {
+    return base;
+  }
+  const result = new URL(base);
+  result.search = '';
+  result.hash = '';
+
+  const normalizedPath = path.startsWith('/') ? path.slice(1) : path;
+
+  result.pathname = result.pathname.endsWith('/')
+    ? `${result.pathname}${normalizedPath}`
+    : `${result.pathname}/${normalizedPath}`;
+
+  return result;
+}

--- a/test/authenticate.test.ts
+++ b/test/authenticate.test.ts
@@ -1,0 +1,161 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import * as jose from 'jose';
+import { v4 as uuidv4 } from 'uuid';
+import {
+  shouldAuthenticate,
+  createGetJWKS,
+  authenticate,
+  type GetJWKS,
+} from '../src/authenticate.ts';
+import { ALG, createApiKey } from '../src/sign.ts';
+import { apiKeyOptions, userClaims, baseIssuer } from './sign.test.ts';
+import { MalformedTokenError, UnauthorizedError } from '../src/errors.ts';
+
+describe('shouldAuthenticate', () => {
+  test('valid token', async () => {
+    const { jwt } = await createApiKey(userClaims(), apiKeyOptions());
+    const promise = shouldAuthenticate(jwt, baseIssuer);
+    await expect(promise).resolves.toBe(true);
+  });
+
+  test('empty token', async () => {
+    const promise = shouldAuthenticate('', baseIssuer);
+    await expect(promise).resolves.toBe(false);
+  });
+
+  test('invalid token', async () => {
+    const promise = shouldAuthenticate('invalid', baseIssuer);
+    await expect(promise).resolves.toBe(false);
+  });
+
+  const invalidClaimsTests: {
+    claims: Record<string, unknown>;
+    baseIssuer?: URL;
+  }[] = [
+    { claims: { iss: null } },
+    { claims: { iss: '' } },
+    { claims: { iss: 42 } },
+    {
+      claims: {
+        iss: `https://example.com/sub_path_without_trailing_slash/${uuidv4()}`,
+      },
+      baseIssuer: new URL(
+        'https://example.com/sub_path_without_trailing_slash'
+      ),
+    },
+    { claims: { iss: `https://susu.dev/${uuidv4()}` } },
+    {
+      claims: { iss: `https://example.com/issuer/not_a_uuid}` },
+      baseIssuer: new URL('https://example.com/issuer'),
+    },
+    { claims: { iss: `https://example.com/${uuidv4()}` } },
+    {
+      claims: { iss: `https://example.com/extra_path/${uuidv4()}` },
+      baseIssuer,
+    },
+    { claims: { ver: null } },
+    { claims: { ver: 42 } },
+    { claims: { ver: '' } },
+    { claims: { ver: 'JAPIKEY-V123' } },
+    { claims: { ver: 'extra-chars-japikey-v1' } },
+    { claims: { ver: 'japikey-v1-extra-suffix' } },
+    { claims: { ver: 'japikey-v1.1' } },
+    { claims: { ver: 'japikey-v1234556' } },
+    { claims: { ver: 'japikey-v99' } },
+  ];
+  test.each(invalidClaimsTests)('invalid claims %s', async data => {
+    const { jwt } = await createApiKey(userClaims(), apiKeyOptions());
+    const validClaims = await jose.decodeJwt(jwt);
+    const validHeader = await jose.decodeProtectedHeader(jwt);
+    const newClaims = { ...validClaims, ...data.claims };
+    const { publicKey, privateKey } = await jose.generateKeyPair(ALG);
+    const token = await new jose.SignJWT(newClaims)
+      .setProtectedHeader({
+        kid: validHeader.kid,
+        alg: ALG,
+      })
+      .sign(privateKey);
+    const promise = shouldAuthenticate(token, data.baseIssuer ?? baseIssuer);
+    await expect(promise).resolves.toBe(false);
+  });
+});
+
+describe('createGetJWKS', () => {
+  let mockFetch: ReturnType<typeof vi.fn>;
+  let jwt: string;
+  let jwks: jose.JSONWebKeySet;
+  let kid: string;
+  let iss: string;
+  beforeEach(async () => {
+    mockFetch = vi.fn();
+    const result = await createApiKey(userClaims(), apiKeyOptions());
+    jwt = result.jwt;
+    jwks = result.jwks;
+    kid = jwks.keys[0].kid!;
+    const unverified = jose.decodeJwt(jwt);
+    iss = unverified.iss!;
+    mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: () => Promise.resolve(jwks),
+    });
+  });
+
+  test('generates the correct URL', async () => {
+    expect(iss).toEqual(`https://example.com/${kid}`);
+
+    const getJWKS = createGetJWKS(baseIssuer, {
+      [jose.customFetch]: mockFetch,
+    });
+    const getKey = getJWKS({ kid, iss: new URL(iss) });
+    const verifyPromise = jose.jwtVerify(jwt, getKey);
+    await expect(verifyPromise).resolves.toBeDefined();
+    await expect(mockFetch).toHaveBeenCalledWith(
+      `https://example.com/${kid}/.well_known/jwks.json`,
+      expect.anything()
+    );
+  });
+
+  test('rejects issuers that do not match', async () => {
+    const differentIssuer = new URL('https://susu.dev');
+    const getJWKS = createGetJWKS(differentIssuer, {
+      [jose.customFetch]: mockFetch,
+    });
+    expect(() => getJWKS({ kid, iss: new URL(iss) })).toThrowError(
+      MalformedTokenError
+    );
+  });
+});
+
+describe('authenticate', () => {
+  test('valid token', async () => {
+    const { jwt, jwks } = await createApiKey(userClaims(), apiKeyOptions());
+    const getJWKS: GetJWKS = ({ kid }) => {
+      return async () => {
+        if (kid !== jwks.keys[0].kid) {
+          throw new Error('Invalid kid');
+        }
+        return jwks.keys[0];
+      };
+    };
+    const promise = authenticate(jwt, { getJWKS, baseIssuer });
+    await expect(promise).resolves.toBeDefined();
+  });
+
+  test('401 when the token is not a JWT', async () => {
+    const getJWKS = createGetJWKS(baseIssuer);
+    const promise = authenticate('not-a-jwt', { getJWKS, baseIssuer });
+    await expect(promise).rejects.toThrowError(MalformedTokenError);
+  });
+
+  test('403 when the public key is not found', async () => {
+    const mockFetch = vi.fn().mockRejectedValue(new Error('Not found'));
+    const getJWKS = createGetJWKS(baseIssuer, {
+      [jose.customFetch]: mockFetch,
+    });
+    const { jwt } = await createApiKey(userClaims(), apiKeyOptions());
+    const promise = authenticate(jwt, { getJWKS, baseIssuer });
+    await expect(promise).rejects.toThrowError(UnauthorizedError);
+  });
+});

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -3,9 +3,10 @@ import {
   errorType,
   UnknownError,
   JapikeyError,
-  InvalidInputError,
   IncorrectUsageError,
   SigningError,
+  MalformedTokenError,
+  UnauthorizedError,
 } from '../src/errors';
 describe('Errors', () => {
   const sampleData = { hello: 'world', meaning: 42 };
@@ -17,14 +18,19 @@ describe('Errors', () => {
       errorType: errorType.INCORRECT_USAGE,
     },
     {
-      err: new InvalidInputError('test'),
-      code: 400,
-      errorType: errorType.INVALID_INPUT,
-    },
-    {
       err: new SigningError('test'),
       code: 500,
       errorType: errorType.SIGNING_ERROR,
+    },
+    {
+      err: new MalformedTokenError('test'),
+      code: 401,
+      errorType: errorType.MALFORMED_TOKEN,
+    },
+    {
+      err: new UnauthorizedError('test'),
+      code: 403,
+      errorType: errorType.UNAUTHORIZED,
     },
   ];
   test.each(tests)(

--- a/test/setupFiles/mockJose.ts
+++ b/test/setupFiles/mockJose.ts
@@ -1,0 +1,20 @@
+import { vi, beforeEach, Mock } from 'vitest';
+import * as jose from 'jose';
+vi.mock('jose', async () => {
+  const actual: typeof jose = await vi.importActual('jose');
+  return {
+    ...actual,
+    generateKeyPair: vi.fn(),
+    exportJWK: vi.fn(),
+    SignJWT: vi.fn(),
+  };
+});
+
+beforeEach(async () => {
+  const actual: typeof jose = await vi.importActual('jose');
+  (jose.generateKeyPair as Mock).mockImplementation(actual.generateKeyPair);
+  (jose.exportJWK as Mock).mockImplementation(actual.exportJWK);
+  (jose.SignJWT as Mock).mockImplementation((payload: jose.JWTPayload) => {
+    return new actual.SignJWT(payload);
+  });
+});

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -1,0 +1,119 @@
+import { describe, test, expect } from 'vitest';
+import { appendPathToUrl } from '../src/util';
+
+describe('appendPathToUrl', () => {
+  const testCases = [
+    // Basic cases
+    {
+      base: 'https://example.com',
+      path: 'api/v1',
+      expected: 'https://example.com/api/v1',
+    },
+    {
+      base: 'https://example.com/',
+      path: 'api/v1',
+      expected: 'https://example.com/api/v1',
+    },
+    {
+      base: 'https://example.com',
+      path: '/api/v1',
+      expected: 'https://example.com/api/v1',
+    },
+    {
+      base: 'https://example.com/',
+      path: '/api/v1',
+      expected: 'https://example.com/api/v1',
+    },
+
+    // Query parameters and anchors (should be dropped)
+    {
+      base: 'https://example.com?param=value',
+      path: 'api/v1',
+      expected: 'https://example.com/api/v1',
+    },
+    {
+      base: 'https://example.com#anchor',
+      path: 'api/v1',
+      expected: 'https://example.com/api/v1',
+    },
+    {
+      base: 'https://example.com?param=value#anchor',
+      path: 'api/v1',
+      expected: 'https://example.com/api/v1',
+    },
+
+    // Username and password (should be preserved)
+    {
+      base: 'https://user:pass@example.com',
+      path: 'api/v1',
+      expected: 'https://user:pass@example.com/api/v1',
+    },
+    {
+      base: 'https://user:pass@example.com/',
+      path: 'api/v1',
+      expected: 'https://user:pass@example.com/api/v1',
+    },
+    {
+      base: 'https://user:pass@example.com?param=value',
+      path: 'api/v1',
+      expected: 'https://user:pass@example.com/api/v1',
+    },
+
+    // Port numbers
+    {
+      base: 'https://example.com:8080',
+      path: 'api/v1',
+      expected: 'https://example.com:8080/api/v1',
+    },
+    {
+      base: 'https://user:pass@example.com:8080',
+      path: 'api/v1',
+      expected: 'https://user:pass@example.com:8080/api/v1',
+    },
+
+    // Complex paths
+    {
+      base: 'https://example.com',
+      path: 'api/v1/users/123',
+      expected: 'https://example.com/api/v1/users/123',
+    },
+    {
+      base: 'https://example.com/',
+      path: '/api/v1/users/123',
+      expected: 'https://example.com/api/v1/users/123',
+    },
+
+    // Empty path
+    {
+      base: 'https://example.com',
+      path: '',
+      expected: 'https://example.com/',
+    },
+    {
+      base: 'https://example.com/',
+      path: '',
+      expected: 'https://example.com/',
+    },
+
+    // Root path
+    {
+      base: 'https://example.com',
+      path: '/',
+      expected: 'https://example.com/',
+    },
+    {
+      base: 'https://example.com/',
+      path: '/',
+      expected: 'https://example.com/',
+    },
+  ];
+
+  test.each(testCases)(
+    'should append path "$path" to base "$base"',
+    ({ base, path, expected }) => {
+      const baseUrl = new URL(base);
+      const result = appendPathToUrl(baseUrl, path);
+      expect(result.toString()).toBe(expected);
+    }
+  );
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
+    setupFiles: ['./test/setupFiles/mockJose.ts'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'html', 'lcov'],


### PR DESCRIPTION
This implements the core methods for verifying an API Key is valid
Following the pattern in the README, it pulls the public key from the ISSUER_URL (after properly verifying it)