### PR TITLE
Add maxAgeSeconds as an option to the jwks routers.

### DIFF
--- a/packages/cloudflare/README.md
+++ b/packages/cloudflare/README.md
@@ -24,7 +24,7 @@ import {
   createApiKeyRouter,
   createJWKSRouter,
   isJWKSPath,
-  type CreateApiKeyRouterOptions,
+  type ApiKeyRouterOptions,
   type CreateApiKeyData,
 } from '@japikey/cloudflare';
 
@@ -75,7 +75,7 @@ export default {
       const db = new D1Driver(env.DB);
       await db.ensureTable();
 
-      const options: CreateApiKeyRouterOptions<Env> = {
+      const options: ApiKeyRouterOptions<Env> = {
         getUserId,
         parseCreateApiKeyRequest,
         issuer: new URL('https://example.com/'),
@@ -91,7 +91,11 @@ export default {
     // Handle JWKS routes
     const baseIssuer = new URL('https://example.com/');
     if (isJWKSPath(request, baseIssuer)) {
-      const jwksRouter = createJWKSRouter(baseIssuer, db);
+      const jwksRouter = createJWKSRouter({
+        baseIssuer,
+        db,
+        maxAgeSeconds: 300,
+      });
       return jwksRouter.fetch(request, env);
     }
 

--- a/packages/cloudflare/src/index.ts
+++ b/packages/cloudflare/src/index.ts
@@ -1,4 +1,4 @@
-import type { CreateApiKeyRouterOptions, CreateApiKeyData } from './router.ts';
+import type { ApiKeyRouterOptions, CreateApiKeyData } from './router.ts';
 import { createApiKeyRouter, createJWKSRouter, isJWKSPath } from './router.ts';
 import D1Driver from './d1.ts';
 
@@ -7,6 +7,6 @@ export {
   createJWKSRouter,
   isJWKSPath,
   D1Driver,
-  type CreateApiKeyRouterOptions,
+  type ApiKeyRouterOptions,
   type CreateApiKeyData,
 };

--- a/packages/express/README.md
+++ b/packages/express/README.md
@@ -25,7 +25,7 @@ import SqliteDriver from '@japikey/sqlite';
 import {
   createApiKeyRouter,
   createJWKSRouter,
-  type CreateRouterOptions,
+  type ApiKeyRouterOptions,
   type CreateApiKeyData,
 } from '@japikey/express';
 const app = express();
@@ -50,7 +50,7 @@ function parseCreateApiKeyRequest(request: Request): Promise<CreateApiKeyData> {
   };
 }
 const db = new SqliteDriver(process.env.SQLITE_PATH);
-const options: CreateRouterOptions = {
+const options: ApiKeyRouterOptions = {
   getUserId,
   parseCreateApiKeyRequest,
   issuer: new URL('https://example.com/'),
@@ -59,7 +59,7 @@ const options: CreateRouterOptions = {
 };
 
 const apiKeyRouter = createApiKeyRouter(options);
-const jwksRouter = createJWKSRouter(db);
+const jwksRouter = createJWKSRouter({ db, maxAgeSeconds: 300 }); // Set the cache-control to invalidate after 5 minutes
 app.use('/api-keys', apiKeyRouter);
 app.use('/', jwksRouter);
 ```


### PR DESCRIPTION
If set, set the cache-control header to that value when responding Otherwise, set a max-age of 0 for the JWKS endpoint when successful

This will allow CDN's to be able to cache the jwks.json endpoint and have the server properly control how long it should be validated

This doesn't bother with non-200 status codes, since it's assumed that a smart cache wouldn't persist those