### PR TITLE
Feature/cloudflare types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Version 0.3.1
+
+This improves the typescript types for the cloudflare package, for compatibility with types in your worker.
+@cloudflare/workers-types is made into a peerDep so the exact version will match.
+Next, to avoid using global vars (request/response), they are imported directly from cloudflare
+Finally, the generics are properly passed down to the request and response objects
+
 # Version 0.3.0
 
 ## Breaking Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@japikey/monorepo",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@japikey/monorepo",
-      "version": "0.1.0",
+      "version": "0.3.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -101,11 +101,11 @@
       }
     },
     "node_modules/@cloudflare/workers-types": {
-      "version": "4.20250806.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20250806.0.tgz",
-      "integrity": "sha512-zPhaMWbwBaxrx2J54SfnKoBiiEQ0scfT8tuu4r5EvLSu82DB+plEFQAZXRdsi6cL04AMpZ43ErSyRPe2KK9cZA==",
-      "dev": true,
-      "license": "MIT OR Apache-2.0"
+      "version": "4.20250810.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20250810.0.tgz",
+      "integrity": "sha512-GAJcKMrlWrrgfpFkYAc9AYiyPM1sMfY0gzrNA7T+J7kVh82hdIWXaz7bykc+B/kgDRteO7RBKfwVEU0rB/hk2Q==",
+      "license": "MIT OR Apache-2.0",
+      "peer": true
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.8",
@@ -5247,10 +5247,10 @@
     },
     "packages/authenticate": {
       "name": "@japikey/authenticate",
-      "version": "0.1.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
-        "@japikey/shared": "0.1.0"
+        "@japikey/shared": "0.3.0"
       },
       "devDependencies": {
         "@types/node": "^24.1.0",
@@ -5270,14 +5270,13 @@
     },
     "packages/cloudflare": {
       "name": "@japikey/cloudflare",
-      "version": "0.1.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
-        "@japikey/japikey": "0.1.0",
+        "@japikey/japikey": "0.3.0",
         "path-to-regexp": "^8.2.0"
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "^4.20250806.0",
         "@types/node": "^24.1.0",
         "@typescript-eslint/eslint-plugin": "^8.38.0",
         "@typescript-eslint/parser": "^8.38.0",
@@ -5292,16 +5291,19 @@
       },
       "engines": {
         "node": ">=22.5.0"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.20250810.0"
       }
     },
     "packages/express": {
       "name": "@japikey/express",
-      "version": "0.1.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
-        "@japikey/authenticate": "0.1.0",
-        "@japikey/japikey": "0.1.0",
-        "@japikey/shared": "0.1.0"
+        "@japikey/authenticate": "0.3.0",
+        "@japikey/japikey": "0.3.0",
+        "@japikey/shared": "0.3.0"
       },
       "devDependencies": {
         "@types/express": "^5.0.0",
@@ -5329,10 +5331,10 @@
     },
     "packages/japikey": {
       "name": "@japikey/japikey",
-      "version": "0.1.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
-        "@japikey/shared": "0.1.0",
+        "@japikey/shared": "0.3.0",
         "jose": "^6.0.12",
         "uuid": "^11.1.0"
       },
@@ -5354,7 +5356,7 @@
     },
     "packages/shared": {
       "name": "@japikey/shared",
-      "version": "0.1.0",
+      "version": "0.3.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^24.1.0",
@@ -5374,10 +5376,10 @@
     },
     "packages/sqlite": {
       "name": "@japikey/sqlite",
-      "version": "0.1.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
-        "@japikey/shared": "0.1.0"
+        "@japikey/shared": "0.3.0"
       },
       "devDependencies": {
         "@types/node": "^24.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@japikey/monorepo",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@japikey/monorepo",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -5247,10 +5247,10 @@
     },
     "packages/authenticate": {
       "name": "@japikey/authenticate",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
-        "@japikey/shared": "0.3.0"
+        "@japikey/shared": "0.3.1"
       },
       "devDependencies": {
         "@types/node": "^24.1.0",
@@ -5270,10 +5270,10 @@
     },
     "packages/cloudflare": {
       "name": "@japikey/cloudflare",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
-        "@japikey/japikey": "0.3.0",
+        "@japikey/japikey": "0.3.1",
         "path-to-regexp": "^8.2.0"
       },
       "devDependencies": {
@@ -5298,12 +5298,12 @@
     },
     "packages/express": {
       "name": "@japikey/express",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
-        "@japikey/authenticate": "0.3.0",
-        "@japikey/japikey": "0.3.0",
-        "@japikey/shared": "0.3.0"
+        "@japikey/authenticate": "0.3.1",
+        "@japikey/japikey": "0.3.1",
+        "@japikey/shared": "0.3.1"
       },
       "devDependencies": {
         "@types/express": "^5.0.0",
@@ -5331,10 +5331,10 @@
     },
     "packages/japikey": {
       "name": "@japikey/japikey",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
-        "@japikey/shared": "0.3.0",
+        "@japikey/shared": "0.3.1",
         "jose": "^6.0.12",
         "uuid": "^11.1.0"
       },
@@ -5356,7 +5356,7 @@
     },
     "packages/shared": {
       "name": "@japikey/shared",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^24.1.0",
@@ -5376,10 +5376,10 @@
     },
     "packages/sqlite": {
       "name": "@japikey/sqlite",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
-        "@japikey/shared": "0.3.0"
+        "@japikey/shared": "0.3.1"
       },
       "devDependencies": {
         "@types/node": "^24.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@japikey/monorepo",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Library to create API keys powered by JWT and JWKS",
   "engines": {
     "node": ">=22.5.0"

--- a/packages/authenticate/package.json
+++ b/packages/authenticate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@japikey/authenticate",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Library to authenticate an API key, in the browser or backend",
   "engines": {
     "node": ">=22.5.0"
@@ -48,7 +48,7 @@
     "format:check": "prettier --check src/**/*.ts"
   },
   "dependencies": {
-    "@japikey/shared": "0.3.0"
+    "@japikey/shared": "0.3.1"
   },
   "devDependencies": {
     "@types/node": "^24.1.0",

--- a/packages/cloudflare/package.json
+++ b/packages/cloudflare/package.json
@@ -48,7 +48,6 @@
     "path-to-regexp": "^8.2.0"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20250806.0",
     "@types/node": "^24.1.0",
     "@typescript-eslint/eslint-plugin": "^8.38.0",
     "@typescript-eslint/parser": "^8.38.0",
@@ -60,5 +59,8 @@
     "prettier": "^3.6.2",
     "rimraf": "^6.0.1",
     "vitest": "^3.2.4"
+  },
+  "peerDependencies": {
+    "@cloudflare/workers-types": "^4.20250810.0"
   }
 }

--- a/packages/cloudflare/package.json
+++ b/packages/cloudflare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@japikey/cloudflare",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Cloudflare worker-based endpoints for japikey",
   "engines": {
     "node": ">=22.5.0"
@@ -44,7 +44,7 @@
     "format:check": "prettier --check src/**/*.ts"
   },
   "dependencies": {
-    "@japikey/japikey": "0.3.0",
+    "@japikey/japikey": "0.3.1",
     "path-to-regexp": "^8.2.0"
   },
   "devDependencies": {

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@japikey/express",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Express endpoints for JAPIKey authentication",
   "engines": {
     "node": ">=22.5.0"
@@ -64,9 +64,9 @@
     "vitest": "^3.2.4"
   },
   "dependencies": {
-    "@japikey/japikey": "0.3.0",
-    "@japikey/authenticate": "0.3.0",
-    "@japikey/shared": "0.3.0"
+    "@japikey/japikey": "0.3.1",
+    "@japikey/authenticate": "0.3.1",
+    "@japikey/shared": "0.3.1"
   },
   "peerDependencies": {
     "express": "^5.0.0"

--- a/packages/japikey/package.json
+++ b/packages/japikey/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@japikey/japikey",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Library to create API keys powered by JWT and JWKS",
   "engines": {
     "node": ">=22.5.0"
@@ -58,7 +58,7 @@
     "vitest": "^3.2.4"
   },
   "dependencies": {
-    "@japikey/shared": "0.3.0",
+    "@japikey/shared": "0.3.1",
     "jose": "^6.0.12",
     "uuid": "^11.1.0"
   }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@japikey/shared",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Shared utilities for JAPIKey",
   "engines": {
     "node": ">=22.5.0"

--- a/packages/sqlite/package.json
+++ b/packages/sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@japikey/sqlite",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "SQLite driver for japikey",
   "engines": {
     "node": ">=22.5.0"
@@ -44,7 +44,7 @@
     "format:check": "prettier --check src/**/*.ts"
   },
   "dependencies": {
-    "@japikey/shared": "0.3.0"
+    "@japikey/shared": "0.3.1"
   },
   "devDependencies": {
     "@types/node": "^24.1.0",


### PR DESCRIPTION
This improves the typescript types for the cloudflare package, for compatibility with types in your worker.
@cloudflare/workers-types is made into a peerDep so the exact version will match.
Next, to avoid using global vars (request/response), they are imported directly from cloudflare
Finally, the generics are properly passed down to the request and response objects